### PR TITLE
Build all release/stable commits as stable builds

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,26 @@
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# (MIT License)
+
+# Each line is a file pattern followed by one or more owners.
+# These owners will be the default owners for everything in
+# the repo.
+* @Cray-HPE/cray-management-systems

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,5 +1,14 @@
 @Library('csm-shared-library') _
 
+void isStable() {
+    echo "Git branch is ${env.GIT_BRANCH}"
+    if ( env.GIT_BRANCH == "release/stable" ){
+        return true
+    } else {
+        return getBuildIsStable(tagIsStable: false)
+    }
+}
+
 pipeline {
     agent {
         label "metal-gcp-builder"
@@ -11,8 +20,8 @@ pipeline {
     }
 
     environment {
-        DESCRIPTION = "Cray product install Helm charts."
-        IS_STABLE = getBuildIsStable()
+        DESCRIPTION = "Helm charts for product installation on CSM systems."
+        IS_STABLE = isStable()
 
         IMPORT_CONFIG_CHART_NAME = "cray-import-config"
         IMPORT_CONFIG_CHART_VERSION = getChartVersion(chartDirectory: 'charts', name: env.IMPORT_CONFIG_CHART_NAME, isStable: env.IS_STABLE)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ version with SemVer.
 
 Create a branch from the default (master) branch and submit a PR. When the PR is merged and
 the base chart is ready to be released for use, merge the default branch to `release/stable`.
+Builds from the `release/stable` branch are stable and all others are "unstable".
 
 ## Versioning
 
@@ -19,19 +20,22 @@ only come from chart versions in the release/stable branch of this repository.
 
 ## Releases
 
-The charts in this repository are subcharts and do not follow the same versioning workflow as most other software.
+The charts in this repository are subcharts and do not follow the same versioning workflow as other CSM software.
 Charts that are built in master/dev/feature/bugfix branches have versions that are appended by the build pipeline
-with a build date and git hash, e.g. `cray-import-config-0.0.2-20201023091619+34aaf71`. However, branches with
-`release/` in their name will only use the Charts SemVer version, e.g. `cray-import-config-0.0.2`.
+with a build date and git hash, e.g. `cray-import-config-0.0.2-20201023091619+34aaf71`. However, charts from the
+`release/stable` branch will only use the Charts SemVer version, e.g. `cray-import-config-0.0.2`.
 
 Users of subcharts should only reference released versions in their chart's requirements file.
 
 When a subchart is ready to be released to consumers, merge master to `release/stable` and then
 communicate to users about the new versions.
 
-Do not use charts from any branch except `release/stable`.
+Do not use charts from any branch except `release/stable` unless you are testing and know
+what you are doing.
 
 Do not create `release/[product]-[version]` branches in this repository as they do not have meaning for base charts.
+
+Tags in this repository will not result in builds/releases.
 
 ## Contributors
 


### PR DESCRIPTION
This repo is different than most of our repos. A lot of base charts that don't follow the CSM branching/release strategy.