### PR TITLE
CASMCMS-7676 Add support for templating IMS recipes

### DIFF
--- a/.license_check.yaml
+++ b/.license_check.yaml
@@ -21,26 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-apiVersion: v2
-name: cray-import-kiwi-recipe-image
-version: 2.1.0
-description: Base chart for importing Cray-authored Kiwi Descriptions and images into
-  IMS/S3 on Shasta systems.
-keywords:
-- ims
-- s3
-- images
-- kiwi
-home: https://github.com/Cray-HPE/cray-product-install-charts
-sources:
-- https://github.com/Cray-HPE/cray-product-install-charts
-maintainers:
-- email: randy.kleinman@hpe.com
-  name: rkleinman
-- email: eric.cozzi@hpe.com
-  name: ecozzi-hpe
-annotations:
-  artifacthub.io/images: |
-    - name: cray-product-catalog-update
-      image: artifactory.algol60.net/csm-docker/stable/cray-product-catalog-update:1.3.1
-  artifacthub.io/license: MIT
+add_exclude:
+  - .env/
+  - .idea/

--- a/charts/cray-import-kiwi-recipe-image/templates/configmap.yaml
+++ b/charts/cray-import-kiwi-recipe-image/templates/configmap.yaml
@@ -1,0 +1,38 @@
+{{/*
+MIT License
+
+(C) Copyright 2022 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+
+{{- if gt (len .Values.import_job.IMS_TEMPLATE_DICTIONARY) 0 -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.import_job.name }}-configmap
+  labels:
+    app.kubernetes.io/name: cray-ims
+data:
+  template_dictionary: |
+    {{- with .Values.import_job.IMS_TEMPLATE_DICTIONARY -}}
+    {{ toYaml . | nindent 4 -}}
+    {{- end }}
+{{- end -}}

--- a/charts/cray-import-kiwi-recipe-image/templates/job.yaml
+++ b/charts/cray-import-kiwi-recipe-image/templates/job.yaml
@@ -1,3 +1,26 @@
+{{/*
+MIT License
+
+(C) Copyright 2022 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -12,6 +35,14 @@ spec:
       - emptyDir:
           medium: Memory
         name: catalog-overlay
+    {{- if gt (len .Values.import_job.IMS_TEMPLATE_DICTIONARY) 0 }}
+      - name: template-dictionary
+        configMap:
+          name: {{ .Values.import_job.name }}-configmap
+          items:
+          - key: template_dictionary
+            path: template_dictionary
+    {{- end }}
       containers:
       - name: update-catalog
         image: "{{ .Values.catalog.image.repository }}:{{ .Values.catalog.image.tag }}"
@@ -54,6 +85,10 @@ spec:
         volumeMounts:
         - mountPath: /results
           name: catalog-overlay
+      {{- if gt (len .Values.import_job.IMS_TEMPLATE_DICTIONARY) 0 }}
+        - name: template-dictionary
+          mountPath: /mnt/image-recipe-import/
+      {{- end }}
         env:
         - name: DOWNLOAD_PATH
           value: "{{ .Values.import_job.DOWNLOAD_PATH }}"

--- a/charts/cray-import-kiwi-recipe-image/values.yaml
+++ b/charts/cray-import-kiwi-recipe-image/values.yaml
@@ -1,3 +1,27 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
 # Full image including repo, e.g. dtr.dev.cray.com/cray/import-image:1.2.3
 #                                                   ^                  ^
 #                                                   |                  |
@@ -28,6 +52,8 @@ import_job:
   name: image-recipe-import
   PRODUCT_NAME: ""
   PRODUCT_VERSION: ""
+
+  IMS_TEMPLATE_DICTIONARY: {}
 
   # cray-ims-load-artifacts image variables, for more information see
   # https://github.com/Cray-HPE/ims-load-artifacts


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Update cray-import-kiwi-recipe-image helm chart to pass dictionary of IMS recipe template keys/values to the ims-load-artifacts container.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-7676](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7676)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `mug`

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Created a test recipe helm chart based on the updated cray-product-install-chart and ims-load-artifacts container. Installed this test recipe helm chart on mug. Saw that the recipe was added to IMS as expected, including that all templating during the helm install occurred as expected. Verified that building the recipe using IMS templated the recipe as expected.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No
- Were continuous integration tests run? If not, why? No
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change? No

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
- [x] Do not merge until CSMv2.5 code can be merged
